### PR TITLE
fixed NdjsonAsyncEnumerableResult ctor

### DIFF
--- a/src/Ndjson.AsyncStreams.AspNetCore.Mvc/NdjsonAsyncEnumerableResult.cs
+++ b/src/Ndjson.AsyncStreams.AspNetCore.Mvc/NdjsonAsyncEnumerableResult.cs
@@ -37,7 +37,7 @@ namespace Ndjson.AsyncStreams.AspNetCore.Mvc
         public NdjsonAsyncEnumerableResult(IAsyncEnumerable<T> values, string mediaType)
         {
             _values = values ?? throw new ArgumentNullException(nameof(values));
-            _mediaType = _mediaType ?? throw new ArgumentNullException(nameof(mediaType));
+            _mediaType = mediaType ?? throw new ArgumentNullException(nameof(mediaType));
         }
 
         /// <summary>


### PR DESCRIPTION
creating a NdjsonAsyncEnumerableResult would always result in the following error because of wrong parameter check: System.ArgumentNullException: Value cannot be null. (Parameter 'mediaType').